### PR TITLE
Demonstrate Shopify AJAX Cart in Headless Environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NACELLE_GRAPHQL_TOKEN=your-public-token
 NACELLE_SPACE_ID=your-space-id
+MYSHOPIFY_DOMAIN=your-myshopify-subdomain.myshopify.com
 
 # `PIM_LOCALE` and `CMS_LOCALE` are used in 
 # ~/services/nacelle-client.js needed to support 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,51 @@
-# Next.js Proof of Concept Site Template
+# Proof of Concept - Nacelle x Next.js Storefront w/Shopify AJAX Cart
 
-This template repository is intended to be used to quickly scaffold new Proof of Concept sites with Next.js. Please update this README to explain the functionality that's demonstrated by your Proof of Concept site.
+This example site is a proof-of-concept which demonstrates the use of a server-side Shopify Cart (via the <a href="https://shopify.dev/docs/themes/ajax-api/reference/cart" target="_blank" rel="noopener">AJAX API</a>) in a Nacelle-powered static (SSG) Next.js storefront.
 
-## Getting Started
+## Quick Start
 
 1. Create a `.env.local` using the environment variables shown in `.env.example`
-2. `npm run dev`
-3. Build something amazing
+2. `npm i` to install dependencies
+3. `npm run dev` to spin up the development server
+4. Visit `http://localhost:3000`
+5. Add to Cart / Remove from Cart to interact with the Shopify cart
+
+## Motivation
+
+Shopify Plus merchants use <a href="https://help.shopify.com/en/manual/checkout-settings/script-editor" target="_blank" rel="noopener">Shopify Scripts</a> to apply discounting rules ("Free shipping when you spend $50 or more," bundling, etc.) to the Shopify cart and checkout.
+
+Because headless Shopify storefronts use a <a href="https://shopify.dev/docs/storefront-api/reference/checkouts/checkoutcreateinput" target="_blank" rel="noopener">simple object</a> to initialize a checkout with the Shopify Storefront API, headless Shopify storefronts don't use the Shopify cart. Rather, it is up to the developer to create a cart and pass its contents to the Shopify Storefront API's <a href="https://shopify.dev/docs/storefront-api/reference/checkouts/checkoutcreate" target="_blank" rel="noopener">`checkoutCreate`</a> GraphQL mutation.
+
+This means that the headless cart is unable to leverage Shopify Scripts. And for the foreseeable future, Shopify won't provide an API endpoint that allows developers to access In order for discounts to appear in the cart and match the discounts available at checkout, the developer must replicate the Shopify Scripts logic (written in Ruby) in their JavaScript-powered frontend framework, or in a serverless function used by the headless cart.
+
+While this approach is tolerable to some merchants and their developers, merchants with a lot of Shopify Scripts logic are reluctant to rewrite and maintain this logic somewhere else. Duplicate discount logic written in another programming language can be difficult to test and trust, and errors + unhandled edge cases can manifest as customer-facing discrepencies between the cart total and the checkout total.
+
+With this in mind, the motivation to explore using Shopify's server-side cart in a headless storefront becomes clear: if it works, it would allow merchants to leverage Shopify Scripts in both their headless site's cart, and on the Shopify-hosted checkout.
+
+## Findings
+
+With some code gymnastics with serverless functions and cookies, it is possible to use the Shopify server-side cart in a headless storefront:
+
+<video width="560" height="240" controls>
+  <source src="https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov">
+</video>
+
+### Intentional Limitations
+
+Note that the <a href="https://poc-nacelle-nextjs-shopify-cart.vercel.app/" target="_blank" rel="noopener">demo site</a> only has two (visible) cart functions that the user can interact with: Add to Cart, and Remove from Cart. This approach is entirely compatible with other traditional cart functions (e.g. updating quantity) - they simply weren't deemed necessary for this POC project.
+
+### Performance
+
+The above video shows that there is some slight latency associated with adding to cart + removing from cart. To deal with this, you could maintain a separate cart object which would be used as the source of truth for the UI. Changes to the cart would then need to be treated as optimistic transactions in which the UI-driving cart object and the Shopify cart are updated asynchronously.
+
+#### Maintaining two carts
+
+Optimistic & asynchronous cart transactions introduces a new set of challenges - how do you deal with situations in which the Shopify server-side cart becomes out-of-sync with the UI-driving cart object, which doesn't depend on successful network requests? This could become problematic for a customer who is shopping on their mobile phone during a train commute with a spotty network connection.
+
+In the event of a desync between the two carts, interval-driven polling of the Shopify AJAX API could be used to re-sync the carts. But building this system introduces complexity that needs to be accounted for when weighing the pros and cons of the headless storefront w/ Shopify AJAX Cart approach.
+
+### Stability
+
+Shopify does not recommend that their AJAX API be used outside of a Shopify Liquid storefront context. There is no implied warranty, and there certainly isn't any guarantee that the cookie gymnastics that power this demo today will work tomorrow. Shopify could make changes to the AJAX API that would render this POC demo unusable, while maintaining backwards-compatibility for Shopify Liquid storefronts.
+
+For these reasons, the approaches used to achieve this POC are not supported, recommended, or endorsed by Nacelle. Please keep this in mind if borrowing any of the patterns used in this repo for your own purposes.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ With some code gymnastics with serverless functions and cookies, it is possible 
 
 <video width="560" height="240" controls>
   <source src="https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov">
+  https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov
 </video>
 
 ### Intentional Limitations

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Shopify Plus merchants use <a href="https://help.shopify.com/en/manual/checkout-
 
 Because headless Shopify storefronts use a <a href="https://shopify.dev/docs/storefront-api/reference/checkouts/checkoutcreateinput" target="_blank" rel="noopener">simple object</a> to initialize a checkout with the Shopify Storefront API, headless Shopify storefronts don't use the Shopify cart. Rather, it is up to the developer to create a cart and pass its contents to the Shopify Storefront API's <a href="https://shopify.dev/docs/storefront-api/reference/checkouts/checkoutcreate" target="_blank" rel="noopener">`checkoutCreate`</a> GraphQL mutation.
 
-This means that the headless cart is unable to leverage Shopify Scripts. And for the foreseeable future, Shopify won't provide an API endpoint that allows developers to access In order for discounts to appear in the cart and match the discounts available at checkout, the developer must replicate the Shopify Scripts logic (written in Ruby) in their JavaScript-powered frontend framework, or in a serverless function used by the headless cart.
+This means that the headless cart is unable to leverage Shopify Scripts. And for the foreseeable future, Shopify won't provide an API endpoint that allows developers to interact with Shopify Scripts in a headless environment. In order for discounts to appear in the cart and match the discounts available at checkout, the developer must replicate the Shopify Scripts logic (written in Ruby) in their JavaScript-powered frontend framework, or in a serverless function used by the headless cart.
 
 While this approach is tolerable to some merchants and their developers, merchants with a lot of Shopify Scripts logic are reluctant to rewrite and maintain this logic somewhere else. Duplicate discount logic written in another programming language can be difficult to test and trust, and errors + unhandled edge cases can manifest as customer-facing discrepencies between the cart total and the checkout total.
 
@@ -24,7 +24,7 @@ With this in mind, the motivation to explore using Shopify's server-side cart in
 
 ## Findings
 
-With some code gymnastics with serverless functions and cookies, it is possible to use the Shopify server-side cart in a headless storefront:
+With some code gymnastics with [serverless functions and cookies](./pages/api/cart/index.js), it is possible to use the Shopify server-side cart in a headless storefront:
 
 <details>
   <summary>Click to Expand AJAX Cart Demo</summary>
@@ -37,11 +37,11 @@ Note that the <a href="https://poc-nacelle-nextjs-shopify-cart.vercel.app/" targ
 
 ### Performance
 
-The above video shows that there is some slight latency associated with adding to cart + removing from cart. To deal with this, you could maintain a separate cart object which would be used as the source of truth for the UI. Changes to the cart would then need to be treated as optimistic transactions in which the UI-driving cart object and the Shopify cart are updated asynchronously.
+The above video shows that there is some latency associated with adding to cart + removing from cart. To deal with this, you could maintain a separate cart object which would be used as the source of truth for the UI. Changes to the cart would then need to be treated as optimistic transactions in which the UI-driving cart object and the Shopify cart are updated asynchronously.
 
 #### Maintaining two carts
 
-Optimistic & asynchronous cart transactions introduces a new set of challenges - how do you deal with situations in which the Shopify server-side cart becomes out-of-sync with the UI-driving cart object, which doesn't depend on successful network requests? This could become problematic for a customer who is shopping on their mobile phone during a train commute with a spotty network connection.
+Optimistic & asynchronous cart transactions introduce a new set of challenges - how do you deal with situations in which the Shopify server-side cart becomes out-of-sync with the UI-driving cart object, which doesn't depend on successful network requests? This could become problematic for a customer who is shopping on their mobile phone during a train commute with a spotty network connection.
 
 In the event of a desync between the two carts, interval-driven polling of the Shopify AJAX API could be used to re-sync the carts. But building this system introduces complexity that needs to be accounted for when weighing the pros and cons of the headless storefront w/ Shopify AJAX Cart approach.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ With this in mind, the motivation to explore using Shopify's server-side cart in
 
 With some code gymnastics with serverless functions and cookies, it is possible to use the Shopify server-side cart in a headless storefront:
 
-<video width="560" height="240" controls>
-  <source src="https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov">
-  https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov
-</video>
+<details>
+  <summary>Click to Expand AJAX Cart Demo</summary>
+  <img src="https://user-images.githubusercontent.com/5732000/113245926-f1cd4780-9285-11eb-8c19-b3e2ceeed5c0.gif" alt="Products being added to cart and removed from cart, with a slight lag time in between clicks and UI changes">
+</details>
 
 ### Intentional Limitations
 

--- a/components/Cart/index.js
+++ b/components/Cart/index.js
@@ -28,7 +28,6 @@ const Cart = () => {
         <h4>SubTotal:</h4>
         <div>{subtotal}</div>
         <div className={styles.checkout}></div>
-
         <h3>Your Cart</h3>
       </header>
       <section>

--- a/components/Cart/index.js
+++ b/components/Cart/index.js
@@ -8,6 +8,11 @@ import styles from "./Cart.module.css";
 const Cart = () => {
   const { cart, fetchCart } = useCart();
   const { isMobile } = useDetectDevice();
+  const cartLocale = window.navigator.language;
+  const cartCurrency = (cart && cart.currency) || "USD";
+  const formatPrice = formatCurrency(cartLocale, cartCurrency);
+  const subtotal =
+    cart && cart.total_price && formatPrice(cart.total_price / 100);
 
   useEffect(() => {
     if (!cart || !Object.keys(cart).length) {
@@ -19,7 +24,7 @@ const Cart = () => {
     <div className={styles.cart}>
       <header>
         <h4>SubTotal:</h4>
-        <div>{calculateSubTotal(cart)}</div>
+        <div>{subtotal}</div>
         <div className={styles.checkout}></div>
 
         <h3>Your Cart</h3>
@@ -28,18 +33,20 @@ const Cart = () => {
         {cart &&
           cart.items &&
           cart.items.map((item) => (
-            <CartItem item={item} key={item.id} isMobile={isMobile} />
+            <CartItem
+              item={item}
+              key={item.id}
+              isMobile={isMobile}
+              formatPrice={formatPrice}
+            />
           ))}
       </section>
     </div>
   );
 };
 
-const CartItem = ({ item }) => {
+const CartItem = ({ item, formatPrice }) => {
   const { removeFromCart } = useCart();
-  const cartLocale = window.navigator.language;
-  const cartCurrency = "USD";
-  const formatPrice = formatCurrency(cartLocale, cartCurrency);
 
   return (
     <div className={styles.item}>
@@ -51,21 +58,5 @@ const CartItem = ({ item }) => {
     </div>
   );
 };
-
-function calculateSubTotal(cart) {
-  const cartLocale = window.navigator.language;
-  const cartCurrency = cart && cart.currency ? cart.currency : "USD";
-  const formatPrice = formatCurrency(cartLocale, cartCurrency);
-
-  const total =
-    cart && cart.items
-      ? cart.items.reduce((subTotal, item) => {
-          const itemTotal = (item.quantity * parseInt(item.price, 10)) / 100;
-          return subTotal + itemTotal;
-        }, 0)
-      : 0;
-
-  return formatPrice(total);
-}
 
 export default Cart;

--- a/components/Cart/index.js
+++ b/components/Cart/index.js
@@ -1,91 +1,69 @@
 import React, { useEffect } from "react";
 import Image from "next/image";
-import { useCheckout, useCart } from "@nacelle/react-hooks";
 import { formatCurrency } from "@nacelle/react-dev-utils";
 
-import useDetectDevice from "hooks/useDetectDevice";
+import { useCart, useDetectDevice } from "hooks";
 import styles from "./Cart.module.css";
 
-const checkoutCredentials = {
-  nacelleSpaceId: process.env.NACELLE_SPACE_ID,
-  nacelleGraphqlToken: process.env.NACELLE_GRAPHQL_TOKEN,
-};
-
 const Cart = () => {
-  const [{ cart }, cartActions] = useCart();
+  const { cart, fetchCart } = useCart();
   const { isMobile } = useDetectDevice();
-  const [checkoutData, checkout, isCheckingOut] = useCheckout(
-    checkoutCredentials,
-    cart
-  );
 
   useEffect(() => {
-    if (checkoutData) {
-      const { processCheckout } = checkoutData.data;
-      window.location = processCheckout.url;
+    if (!cart || !Object.keys(cart).length) {
+      fetchCart();
     }
-  }, [checkoutData]);
+  }, [cart]);
 
   return (
     <div className={styles.cart}>
       <header>
         <h4>SubTotal:</h4>
         <div>{calculateSubTotal(cart)}</div>
-        <div className={styles.checkout}>
-          <button onClick={checkout} disabled={!cart.length || isCheckingOut}>
-            {isCheckingOut ? "Processing Cart..." : "Checkout"}
-          </button>
-        </div>
+        <div className={styles.checkout}></div>
 
         <h3>Your Cart</h3>
       </header>
       <section>
-        {cart.map((item) => (
-          <CartItem
-            item={item}
-            key={item.id}
-            cartActions={cartActions}
-            isMobile={isMobile}
-          />
-        ))}
+        {cart &&
+          cart.items &&
+          cart.items.map((item) => (
+            <CartItem item={item} key={item.id} isMobile={isMobile} />
+          ))}
       </section>
     </div>
   );
 };
 
-const CartItem = ({ item, cartActions, isMobile }) => {
-  const formatPrice = formatCurrency(item.locale, item.priceCurrency);
-
-  const removeItemFromCart = () => cartActions.removeFromCart(item);
+const CartItem = ({ item }) => {
+  const { removeFromCart } = useCart();
+  const cartLocale = window.navigator.language;
+  const cartCurrency = "USD";
+  const formatPrice = formatCurrency(cartLocale, cartCurrency);
 
   return (
     <div className={styles.item}>
-      <Image src={item.image.thumbnailSrc} width="100" height="70" />
-
+      <Image src={item.image} width="100" height="70" />
       <div>
-        {/* <div>
-          <h4>{item.title}</h4>
-          <span className={styles.price}>{formatPrice(item.price)}</span>
-        </div> */}
-
-        <div>
-          <div className={styles.price}>{formatPrice(item.price)}</div>
-          <button onClick={removeItemFromCart}>Remove</button>
-        </div>
+        <div className={styles.price}>{formatPrice(item.price / 100)}</div>
+        <button onClick={() => removeFromCart(item)}>Remove</button>
       </div>
     </div>
   );
 };
 
 function calculateSubTotal(cart) {
-  const cartLocale = cart.length ? cart[0].locale : "en-us";
-  const cartCurrency = cart.length ? cart[0].priceCurrency : "USD";
+  const cartLocale = window.navigator.language;
+  const cartCurrency = cart && cart.currency ? cart.currency : "USD";
   const formatPrice = formatCurrency(cartLocale, cartCurrency);
 
-  const total = cart.reduce((subTotal, item) => {
-    const itemTotal = item.quantity * parseInt(item.price, 10);
-    return subTotal + itemTotal;
-  }, 0);
+  const total =
+    cart && cart.items
+      ? cart.items.reduce((subTotal, item) => {
+          const itemTotal = (item.quantity * parseInt(item.price, 10)) / 100;
+          return subTotal + itemTotal;
+        }, 0)
+      : 0;
 
   return formatPrice(total);
 }

--- a/components/Cart/index.js
+++ b/components/Cart/index.js
@@ -12,7 +12,9 @@ const Cart = () => {
   const cartCurrency = (cart && cart.currency) || "USD";
   const formatPrice = formatCurrency(cartLocale, cartCurrency);
   const subtotal =
-    cart && cart.total_price && formatPrice(cart.total_price / 100);
+    cart && cart.total_price
+      ? formatPrice(cart.total_price / 100)
+      : formatPrice(0);
 
   useEffect(() => {
     if (!cart || !Object.keys(cart).length) {

--- a/components/Layout/index.js
+++ b/components/Layout/index.js
@@ -8,7 +8,7 @@ export default function Layout({ children }) {
   return (
     <>
       <div className={styles.header}>
-        <h1 className="app">Proof of Concept: Some Cool Feature</h1>
+        <h1 className="app">Proof of Concept: Headless Shopify AJAX Cart</h1>
       </div>
       <Cart className={styles.cart} css={{ position: "fixed" }} />
       <main>{children}</main>

--- a/components/ProductCard/ProductCard.module.css
+++ b/components/ProductCard/ProductCard.module.css
@@ -19,4 +19,5 @@
   border: 1px solid black;
   padding: 0.8em 1.2em;
   margin-bottom: 1em;
+  cursor: pointer;
 }

--- a/components/ProductCard/index.js
+++ b/components/ProductCard/index.js
@@ -1,20 +1,24 @@
 import React from "react";
-import { useCart } from "@nacelle/react-hooks";
 
+import { useCart } from "~/hooks";
 import styles from "./ProductCard.module.css";
 
 export default function ProductCard({ product }) {
-  const [, cartActions] = useCart();
   const lineItem = { ...product, variant: product.variants[0], quantity: 1 };
+  const { addToCart } = useCart();
 
   return (
     <div className={`product-card ${styles.card}`}>
       <h2>{product.title}</h2>
-      <img src={product.featuredMedia.src} className={styles.image} />
-      <button
-        className={styles.button}
-        onClick={() => cartActions.addToCart(lineItem)}
-      >
+      <img
+        src={
+          product.featuredMedia
+            ? product.featuredMedia.src
+            : product.featured_image.url
+        }
+        className={styles.image}
+      />
+      <button className={styles.button} onClick={() => addToCart(lineItem)}>
         Add to Cart
       </button>
     </div>

--- a/context/index.js
+++ b/context/index.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const CartContext = React.createContext();

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,1 +1,2 @@
+export { default as useCart } from "./useCart";
 export { default as useDetectDevice } from "./useDetectDevice";

--- a/hooks/useCart.js
+++ b/hooks/useCart.js
@@ -1,4 +1,6 @@
 import { useContext, useCallback } from "react";
+import fetch from "isomorphic-unfetch";
+
 import { CartContext } from "~/context";
 
 export default function useCart() {
@@ -11,7 +13,6 @@ export default function useCart() {
   const fetchCart = useCallback(() => {
     // initialize or refresh the Shopify cart
     return fetch("/api/cart", {
-      mode: "cors",
       headers: {
         "Content-Type": "application/json",
       },

--- a/hooks/useCart.js
+++ b/hooks/useCart.js
@@ -10,7 +10,7 @@ export default function useCart() {
 
   const fetchCart = useCallback(() => {
     // initialize or refreshe the Shopify cart
-    fetch("/api/cart", {
+    return fetch("/api/cart", {
       mode: "cors",
       headers: {
         "Content-Type": "application/json",
@@ -23,7 +23,8 @@ export default function useCart() {
 
   const addToCart = useCallback((lineItem) => {
     const { quantity, variants } = lineItem;
-    fetch("/api/cart", {
+
+    return fetch("/api/cart", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -44,11 +45,11 @@ export default function useCart() {
       .then(() => fetchCart());
   }, []);
 
-  const removeFromCart = useCallback(async (lineItem) => {
+  const removeFromCart = useCallback((lineItem) => {
     const updates = {};
     updates[lineItem.id] = 0;
 
-    await fetch("/api/cart", {
+    return fetch("/api/cart", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/hooks/useCart.js
+++ b/hooks/useCart.js
@@ -9,7 +9,7 @@ export default function useCart() {
   }, []);
 
   const fetchCart = useCallback(() => {
-    // initialize or refreshe the Shopify cart
+    // initialize or refresh the Shopify cart
     return fetch("/api/cart", {
       mode: "cors",
       headers: {

--- a/hooks/useCart.js
+++ b/hooks/useCart.js
@@ -1,0 +1,70 @@
+import { useContext, useCallback } from "react";
+import { CartContext } from "~/context";
+
+export default function useCart() {
+  const { cart, setCart: setCartContext } = useContext(CartContext);
+
+  const setCart = useCallback((newCartData) => {
+    setCartContext(newCartData);
+  }, []);
+
+  const fetchCart = useCallback(() => {
+    // initialize or refreshe the Shopify cart
+    fetch("/api/cart", {
+      mode: "cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => setCart(data))
+      .catch((err) => err);
+  }, []);
+
+  const addToCart = useCallback((lineItem) => {
+    const { quantity, variants } = lineItem;
+    fetch("/api/cart", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        action: "add",
+        payload: {
+          items: [
+            {
+              id: atob(variants[0].id).split("/").pop(),
+              quantity,
+            },
+          ],
+        },
+      }),
+    })
+      .then((res) => res.json())
+      .then(() => fetchCart());
+  }, []);
+
+  const removeFromCart = useCallback(async (lineItem) => {
+    const updates = {};
+    updates[lineItem.id] = 0;
+
+    await fetch("/api/cart", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "update",
+        payload: { updates },
+      }),
+    })
+      .then((res) => res.json())
+      .then((data) => setCart(data));
+  }, []);
+
+  return {
+    cart,
+    setCart,
+    fetchCart,
+    addToCart,
+    removeFromCart,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -951,6 +951,15 @@
         "isarray": "1.0.0"
       }
     },
+    "isomorphic-unfetch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "requires": {
+        "node-fetch": "^2.6.1",
+        "unfetch": "^4.2.0"
+      }
+    },
     "iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
@@ -1771,6 +1780,11 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+    },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@nacelle/react-dev-utils": "^2.10.1",
     "@nacelle/react-hooks": "^2.12.0",
     "@react-hook/media-query": "^1.1.1",
+    "isomorphic-unfetch": "^3.1.0",
     "next": "^10.0.9",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,13 +1,14 @@
-import React from "react";
+import React, { useState } from "react";
 import Head from "next/head";
-import { CartProvider } from "@nacelle/react-hooks";
 
 import "~/styles.css";
 import { Layout } from "~/components";
+import { CartContext } from "~/context";
 
 export default function App({ Component, pageProps }) {
+  const [cart, setCart] = useState(null);
   return (
-    <CartProvider useLocalStorage>
+    <CartContext.Provider value={{ cart, setCart }}>
       <Head>
         <title>Proof of Concept</title>
         <meta charSet="utf-8" />
@@ -16,6 +17,6 @@ export default function App({ Component, pageProps }) {
       <Layout>
         <Component {...pageProps} />
       </Layout>
-    </CartProvider>
+    </CartContext.Provider>
   );
 }

--- a/pages/api/cart/index.js
+++ b/pages/api/cart/index.js
@@ -1,0 +1,86 @@
+import fetch from "isomorphic-unfetch";
+
+const getCookieString = (cookiesObj) =>
+  Object.keys(cookiesObj)
+    .map((key) => `${key}=${cookiesObj[key]};`)
+    .join(" ");
+
+const filterCookieAttributes = (cookies) =>
+  cookies.split(" SameSite=Lax,").map((cookie) =>
+    cookie
+      .split("; ")
+      .filter((x) => !x.toLowerCase().startsWith("domain"))
+      .filter((x) => !x.toLowerCase().startsWith("path"))
+      .join("; ")
+  );
+
+async function shopifyAjaxRequest({ req, res, endpoint, method, payload }) {
+  const requestOptions = {
+    method,
+    headers: {
+      cookie: getCookieString(req.cookies),
+    },
+  };
+
+  if (method === "POST" && payload) {
+    requestOptions.body = JSON.stringify(payload);
+    requestOptions.headers["Content-Type"] = "application/json";
+  }
+
+  try {
+    let cookies, status;
+    const response = await fetch(endpoint, requestOptions).then((res) => {
+      cookies = filterCookieAttributes(res.headers.get("set-cookie"));
+      status = res.status;
+
+      return res.json();
+    });
+
+    res.setHeader("Set-Cookie", cookies);
+    res.status(status).send(response);
+  } catch (err) {
+    res.status(500).send(err);
+  }
+}
+
+export default async function handler(req, res) {
+  const subdomain = process.env.MYSHOPIFY_DOMAIN.split(".").shift();
+  const baseUrl = `https://${subdomain}.myshopify.com`;
+  const {
+    method,
+    body: { action, payload },
+  } = req;
+
+  if (!subdomain) {
+    res.status(400).send("Missing environment variable: MYSHOPIFY_DOMAIN");
+  }
+
+  if (method === "GET") {
+    await shopifyAjaxRequest({
+      req,
+      res,
+      method,
+      endpoint: `${baseUrl}/cart.js`,
+    });
+  } else if (method === "POST") {
+    if (!action) {
+      res
+        .status(400)
+        .send(
+          "POST requests to /api/cart require an `action` ('add', 'update', etc.) in the request body"
+        );
+    }
+
+    await shopifyAjaxRequest({
+      req,
+      res,
+      method,
+      endpoint: `${baseUrl}/cart/${action}.js`,
+      payload,
+    });
+  } else {
+    res
+      .status(400)
+      .send("The /cart endpoint is only configured for GET and POST requests");
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { nacelleClient } from "~/services";
 import { ProductCard } from "~/components";
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [ComponentName] (if applicable), for example: [Button]
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes [DMS-1303](https://nacelle.atlassian.net/browse/DMS-1303)

> As a merchant developer, I want to see an example of using the Shopify AJAX API in a headless Next.js storefront, so that I can be familiar with the patterns involved with syncing display prices between my PWA cart and my Shopify checkout

<!--
  Context about the problem that’s being addressed. Use bullets or ordered lists for multiple touch points.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.

  Before / after screenshots are appreciated for UI changes. Make sure to include alt text that describes the screenshot.

  If you include an animated gif showing your change, wrapping it in a details tag is recommended. Gifs usually autoplay, which can cause accessibility issues for people reviewing your PR:

    <details>
      <summary>Summary of your gif(s)</summary>
      <img src="..." alt="Description of what the gif shows">
    </details>
-->

This PR replaces the traditional headless cart (provided by `@nacelle/react-hooks`'s `useCart` hook) with the server-side Shopify AJAX Cart.

#### Demonstration

https://user-images.githubusercontent.com/5732000/113243585-4e7a3380-9281-11eb-88fc-355adef89f2d.mov

## <!-- ℹ️ Delete the following for small / trivial changes -->

### How to Test

1. Create a `.env.local` using the environment variables shown in `.env.example`
2. `npm i` to install dependencies
3. `npm run dev` to spin up the development server
4. Visit `http://localhost:3000`
5. Add to Cart / Remove from Cart to interact with the Shopify cart

> NOTE: If you want to test that Shopify Scripts discounts are applied to the cart, you'll need to use a Nacelle space which is tied to a Shopify Plus store with Shopify Scripts discount logic that you're familiar with.

### Testing checklist

* [x] Updated the `README.md` with documentation changes
